### PR TITLE
Corrected the error

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -205,8 +205,8 @@ class _LoginPageState extends State<LoginPage> {
 
   Future<FirebaseUser> signIn(String email, String password) async {
     try {
-      FirebaseUser user = await auth.signInWithEmailAndPassword(
-          email: email, password: password);
+      FirebaseUser user = (await auth.signInWithEmailAndPassword(
+          email: email, password: password)).user;
 
       assert(user != null);
       assert(await user.getIdToken() != null);
@@ -231,7 +231,7 @@ class _LoginPageState extends State<LoginPage> {
         idToken: googleAuth.idToken,
       );
 
-      final FirebaseUser user = await auth.signInWithCredential(credential);
+      final FirebaseUser user = (await auth.signInWithCredential(credential)).user;
       assert(user.email != null);
       assert(user.displayName != null);
       assert(!user.isAnonymous);


### PR DESCRIPTION
When we try to get back the output from auth.signInWithEmailAndPassword we were getting an error saying type auth cannot be assigned to type Firebase user.
I have corrected this error so no one in future gets the same error when they are trying to learn about login and signup from your repo.